### PR TITLE
SOF-430 Fix image trash icon and styling

### DIFF
--- a/src/components/questions/ImageSelector.tsx
+++ b/src/components/questions/ImageSelector.tsx
@@ -111,6 +111,13 @@ const ImageSelector = (props: {
               />
             </View>
             <View style={styles.imageButtons}>
+              <View
+                pointerEvents="none"
+                accessible={true}
+                accessibilityLabel="Afbeelding vergroten knop"
+              >
+                <Icon name="expand" color={COLORS.black} size={48} />
+              </View>
               <TouchableOpacity
                 onPress={() => RemoveImage()}
                 accessible={true}
@@ -157,7 +164,7 @@ const styles = StyleSheet.create({
   },
   imageButtons: {
     display: 'flex',
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between',
     flexDirection: 'row',
 
     position: 'absolute',

--- a/src/components/questions/ImageSelector.tsx
+++ b/src/components/questions/ImageSelector.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import {
   StyleSheet,
-  Text,
   View,
   TouchableOpacity,
   AccessibilityInfo,
@@ -99,45 +98,43 @@ const ImageSelector = (props: {
         {image ? (
           <>
             <View
-              style={styles.imgStyle}
-              ref={imageModal}
+              style={styles.imageContainer}
               accessible={true}
               accessibilityLabel={'Gemaakte afbeelding'}
             >
               <ImageModal
-                modalImageResizeMode="contain"
+                resizeMode="contain"
                 style={styles.imgStyle}
                 source={{
                   uri: fixMediaUri(image),
                 }}
               />
             </View>
-            <TouchableOpacity
-              style={styles.icon}
-              onPress={() => RemoveImage()}
-              accessible={true}
-              accessibilityLabel="Verwijder afbeelding knop"
-            >
-              <Icon name="remove" color={COLORS.black} size={48} />
-            </TouchableOpacity>
+            <View style={styles.imageButtons}>
+              <TouchableOpacity
+                onPress={() => RemoveImage()}
+                accessible={true}
+                accessibilityLabel="Verwijder afbeelding knop"
+              >
+                <Icon name="trash" color={COLORS.black} size={48} />
+              </TouchableOpacity>
+            </View>
           </>
-        ) : (
-          <Text />
-        )}
+        ) : null}
         <View style={styles.rowContainer}>
           <TouchableOpacity
             activeOpacity={0.5}
             onPress={() => RequestCameraPermission()}
             accessibilityLabel={'Open camera knop'}
           >
-            <Icon name="camera" style={styles.imagePadding} size={48} color={COLORS.black} />
+            <Icon name="camera" style={styles.rowContainerChild} size={48} color={COLORS.black} />
           </TouchableOpacity>
           <TouchableOpacity
             activeOpacity={0.5}
             onPress={() => PickImageFromGallery()}
             accessibilityLabel={'Open galerij knop'}
           >
-            <Icon name="image" size={48} color={COLORS.black} />
+            <Icon name="image" style={styles.rowContainerChild} size={48} color={COLORS.black} />
           </TouchableOpacity>
         </View>
       </View>
@@ -147,27 +144,35 @@ const ImageSelector = (props: {
 
 const styles = StyleSheet.create({
   container: {
-    padding: 10,
-    alignItems: 'flex-end',
+    position: 'relative',
   },
-  rowContainer: {
-    flexDirection: 'row',
-    marginTop: 10,
-  },
-  imagePadding: {
-    paddingEnd: 15,
-  },
-  icon: {
-    position: 'absolute',
-    end: 0,
-    top: 0,
-    color: COLORS.black,
+  imageContainer: {
+    borderWidth: 2,
+    borderColor: COLORS.black,
+    borderRadius: 10,
   },
   imgStyle: {
-    width: 150,
-    height: 150,
-    resizeMode: 'center',
-    alignSelf: 'center',
+    width: '100%',
+    aspectRatio: 2,
+  },
+  imageButtons: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    flexDirection: 'row',
+
+    position: 'absolute',
+    width: '100%',
+    padding: 20,
+  },
+  rowContainer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    flexDirection: 'row',
+    width: '100%',
+    padding: 5,
+  },
+  rowContainerChild: {
+    padding: 5,
   },
 });
 


### PR DESCRIPTION
## Description

Kruisje verandert naar prullenbakje en de image heeft nu dezelfde styling als de video

## Review focus

Even checken of de styling juist is

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos

<details>
<summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/49717888/171999273-116159d2-ce22-4858-adbd-8ab194ce7e92.png)
</details>
