### PR TITLE
SOF-509 Fix type and name for video upload

### DIFF
--- a/src/components/questions/VideoSelector.tsx
+++ b/src/components/questions/VideoSelector.tsx
@@ -24,7 +24,7 @@ const VideoSelector = (props: {
     if (video) {
       props.onVideoSelected({
         uri: video,
-        type: `video/mp4`,
+        type: 'video/mp4',
         name: 'video-recording.mp4',
       });
     }

--- a/src/components/questions/VideoSelector.tsx
+++ b/src/components/questions/VideoSelector.tsx
@@ -24,8 +24,8 @@ const VideoSelector = (props: {
     if (video) {
       props.onVideoSelected({
         uri: video,
-        type: `video/${getLastItemFromSplit(video, '.')}`,
-        name: getLastItemFromSplit(video, '/'),
+        type: `video/mp4`,
+        name: 'video-recording.mp4',
       });
     }
   } catch (_) {}

--- a/src/components/questions/VideoSelector.tsx
+++ b/src/components/questions/VideoSelector.tsx
@@ -8,7 +8,6 @@ import permissionCheck from '../utility/PermissionCheck';
 //@ts-ignore next-line
 import Video from 'react-native-video';
 import { FileSelectedData } from '../../models/questionOptionExtraData/FileSelectedData';
-import getLastItemFromSplit from '../../helpers/splitHelper';
 import { useNavigation } from '@react-navigation/native';
 
 const VideoSelector = (props: {


### PR DESCRIPTION
**Closes #XX**

## Description

Video type and name is now a static value, the values from the callback are not usable:
``"name": "714570276", "type": "video/contentprovider/-1/2/content%3A%2F%2Fmedia%2Fexternal%2Fvideo%2Fmedia%2F60/ORIGINAL/NONE/video%2Fmp4/714570276"``

## Review focus

<!-- Describe what reviewers should concentrate on (e.g. things you think could be implemented better, or made more efficient) -->

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos

<details>
<summary>Click to expand</summary>

<!-- upload any screenshots or recordings demonstrating the issue here-->

</details>
